### PR TITLE
Add Docker driver

### DIFF
--- a/lib/mate/config.ex
+++ b/lib/mate/config.ex
@@ -58,6 +58,7 @@ defmodule Mate.Config do
     :module,
     :steps,
     driver: Mate.Driver.SSH,
+    driver_opts: [],
     mix_env: :dev,
     clean_paths: ~w{_build rel priv/generated priv/static},
     remotes: []
@@ -68,6 +69,7 @@ defmodule Mate.Config do
           module: String.t(),
           steps: list(atom()) | function() | nil,
           driver: atom(),
+          driver_opts: keyword(),
           mix_env: atom(),
           clean_paths: list(String.t()),
           remotes: list(Remote.t())

--- a/lib/mate/driver.ex
+++ b/lib/mate/driver.ex
@@ -5,9 +5,10 @@ defmodule Mate.Driver do
   The idea behind supporting multiple drivers is allowing the user to decide
   how and where they want to build their application. By default is will use
   the SSH driver, but maybe in the near future there will be other built-in
-  drivers. It is also possible to write your own, of course.
+  drivers. It is also possible to write your own, of course. For an example I
+  recommend looking at `Mate.Driver.SSH`.
 
-  For an example I recommend looking at `Mate.Driver.SSH`.
+  **NOTE:** Deployments currently always use the `Mate.Driver.SSH`.
   """
   alias Mate.Session
 

--- a/lib/mate/driver.ex
+++ b/lib/mate/driver.ex
@@ -39,6 +39,17 @@ defmodule Mate.Driver do
               {:ok, Session.t()} | {:error, String.t()}
 
   @doc """
+  Executes a script using the driver
+  """
+  @callback exec_script(session :: Session.t(), script :: String.t()) ::
+              {:ok, Session.t()} | {:error, String.t()}
+
+  @doc """
+  Prepare source
+  """
+  @callback prepare_source(session :: Session.t()) :: {:ok, Session.t()} | {:error, String.t()}
+
+  @doc """
   Copy a file from remote to local
   """
   @callback copy_from(session :: Session.t(), src :: String.t(), dest :: String.t()) ::
@@ -56,5 +67,5 @@ defmodule Mate.Driver do
   """
   @callback close(session :: Session.t()) :: {:ok, Session.t()}
 
-  @optional_callbacks close: 1
+  @optional_callbacks close: 1, prepare_source: 1
 end

--- a/lib/mate/driver/docker.ex
+++ b/lib/mate/driver/docker.ex
@@ -217,6 +217,11 @@ defmodule Mate.Driver.Docker do
   end
 
   @impl true
+  def terminate(_msg, state) do
+    handle_call(:stop, {}, state)
+  end
+
+  @impl true
   def handle_info({conn, {:data, _data}}, %{conn: conn} = state) do
     # TODO: Logging (optional?)
     {:noreply, state}

--- a/lib/mate/driver/docker.ex
+++ b/lib/mate/driver/docker.ex
@@ -1,0 +1,193 @@
+defmodule Mate.Driver.Docker do
+  @moduledoc """
+  The Docker driver is used to execute commands via Docker.
+
+  Configure the docker image to use by setting it as the `build_server` in your
+  local `.mate.exs` configuration file. The image you are using should contain
+  everything you need for your application, for example Elixir and NodeJS.
+  """
+  alias Mate.Utils
+  use Mate.Session
+  use Mate.Driver
+  use GenServer
+
+  @impl true
+  def start(session, host) do
+    with {:ok, conn} <-
+           GenServer.start_link(__MODULE__, %{
+             conn: nil,
+             host: host,
+             args: [],
+             docker_bin: nil,
+             container_name: nil,
+             container_id: nil,
+             session: session
+           }) do
+      {:ok, session |> set_conn(conn)}
+    else
+      {:error, _} = error -> error
+    end
+  end
+
+  @impl true
+  def close(%Session{conn: conn} = session) do
+    GenServer.stop(conn, :normal, 5_000)
+    {:ok, session}
+  end
+
+  @impl true
+  def exec(%Session{conn: conn}, command, args) do
+    GenServer.call(conn, {:exec, command, args}, :infinity)
+  end
+
+  @impl true
+  def exec_script(session, script) do
+    exec(session, "bash", ["-c", script])
+  end
+
+  @impl true
+  def prepare_source(%Session{conn: conn, remote: remote} = session) do
+    # Create the build dir
+    GenServer.call(conn, {:exec, "mkdir", ["-p", remote.build_path]})
+
+    # Clone from the mounted "/repo" dir to the build dir
+    GenServer.call(
+      conn,
+      {:exec, "git", ["clone", "--depth", "1", "/repo", remote.build_path]},
+      :infinity
+    )
+
+    {:ok, session}
+  end
+
+  @impl true
+  def copy_from(%Session{conn: conn}, remote_src, local_dest) do
+    GenServer.call(conn, {:copy, :from, remote_src, local_dest}, :infinity)
+  end
+
+  @impl true
+  def copy_to(%Session{conn: conn}, local_src, remote_dest) do
+    GenServer.call(conn, {:copy, :to, local_src, remote_dest}, :infinity)
+  end
+
+  @impl true
+  def init(state) do
+    container_name = "mate-" <> Utils.random_id(6)
+
+    docker_bin = System.find_executable("docker")
+    if is_nil(docker_bin), do: Mix.raise("Cannot find the docker binary on your local machine.")
+
+    run_wrapper = Application.app_dir(:mate, "priv/run-wrapper.sh")
+    current_dir = File.cwd!()
+
+    command = [
+      docker_bin,
+      "run",
+      "--rm",
+      "-t",
+      "-v",
+      current_dir <> ":/repo",
+      "--name",
+      container_name,
+      state.host,
+      "/bin/bash" | state.args
+    ]
+
+    opts = [:stream, :binary, :exit_status, :hide, :use_stdio, args: command]
+    conn = Port.open({:spawn_executable, run_wrapper}, opts)
+
+    # Awaiting container to become available
+    result =
+      Enum.reduce_while(1..50, {:error, :no_connection}, fn _i, acc ->
+        System.cmd(docker_bin, ["ps", "-aqf", "name=^#{container_name}$"], stderr_to_stdout: true)
+        |> case do
+          {container_id, _exit_status} ->
+            container_id = String.trim(container_id)
+
+            if container_id != "" do
+              {:halt, {:ok, container_id}}
+            else
+              :timer.sleep(1000)
+              {:cont, acc}
+            end
+        end
+      end)
+
+    case result do
+      {:error, reason} ->
+        {:stop, reason}
+
+      {:ok, container_id} ->
+        {:ok,
+         %{
+           state
+           | conn: conn,
+             docker_bin: docker_bin,
+             container_id: container_id,
+             container_name: container_name
+         }}
+    end
+  end
+
+  @impl true
+  def handle_call({:exec, command, user_args}, _, state) do
+    container_id = state.container_id
+    docker_bin = state.docker_bin
+
+    args = ["exec", "-t", container_id, command | user_args]
+
+    case System.cmd(docker_bin, args, stderr_to_stdout: true) do
+      {stdout, _exit_status = 0} ->
+        {:reply, {:ok, String.trim(stdout)}, state}
+
+      {stdout, exit_status} ->
+        {:reply,
+         {:error,
+          "Remote command exited with non-ok exit status (#{exit_status})\n\nCommand: #{command} #{Enum.join(user_args, " ")}\nOutput:\n#{stdout}"},
+         state}
+    end
+  end
+
+  def handle_call({:copy, direction, src, dest}, _, state) do
+    container_id = state.container_id
+    docker_bin = state.docker_bin
+
+    src =
+      if direction == :from,
+        do: container_id <> ":" <> src,
+        else: src
+
+    dest =
+      if direction == :to,
+        do: container_id <> ":" <> dest,
+        else: dest
+
+    args = ["cp", src, dest]
+
+    case System.cmd(docker_bin, args, stderr_to_stdout: true) do
+      {stdout, _exit_status = 0} ->
+        {:reply, {:ok, String.trim(stdout)}, state}
+
+      {stdout, exit_status} ->
+        {:reply,
+         {:error,
+          "Failed to copy #{src} command exited with non-ok exit status (#{exit_status})\nOutput:\n#{stdout}"},
+         state}
+    end
+  end
+
+  @impl true
+  def handle_info({conn, {:data, _data}}, %{conn: conn} = state) do
+    # TODO: Logging (optional?)
+    {:noreply, state}
+  end
+
+  def handle_info({conn, {:exit_status, 0}}, %{conn: conn} = state) do
+    # TODO: Logging (optional?)
+    {:noreply, state}
+  end
+
+  def handle_info({conn, {:exit_status, status}}, %{conn: conn} = _state) do
+    Mix.raise("Docker exited unexpectedly with exit code #{status}")
+  end
+end

--- a/lib/mate/helpers.ex
+++ b/lib/mate/helpers.ex
@@ -134,6 +134,18 @@ defmodule Mate.Helpers do
     driver.copy_to(session, src, dest)
   end
 
+  @spec bail(Mate.Session.t(), String.t()) :: no_return
+  @spec bail(Mate.Session.t(), String.t(), String.t()) :: no_return
+  def bail(%{driver: driver} = session, message, error \\ "") do
+    if function_exported?(driver, :close, 1) do
+      driver.close(session)
+    end
+
+    if error != "",
+      do: Mix.raise("#{message}\r\n\r\n#{error}"),
+      else: Mix.raise(message)
+  end
+
   @spec print_result({:ok, String.t()} | {:error, String.t()}, String.t(), integer()) ::
           {:ok, String.t()} | {:error, String.t()}
   defp print_result({:ok, stdout} = result, tag, verbosity) when verbosity > 1 do

--- a/lib/mate/helpers.ex
+++ b/lib/mate/helpers.ex
@@ -56,7 +56,7 @@ defmodule Mate.Helpers do
     if session.verbosity > 0,
       do: Mix.shell().info([:yellow, "local >", :reset, " ", script])
 
-    case System.cmd("/usr/bin/env", ["bash", "-c", script], stderr_to_stdout: true) do
+    case System.cmd("/usr/bin/env", [script], stderr_to_stdout: true) do
       {stdout, _exit_status = 0} ->
         {:ok, String.trim(stdout)}
 
@@ -85,7 +85,7 @@ defmodule Mate.Helpers do
     if session.verbosity > 0,
       do: Mix.shell().info([:yellow, "remote > ", :reset, " ", script])
 
-    driver.exec(session, script, [])
+    driver.exec_script(session, script)
     |> print_result("remote", session.verbosity)
   end
 

--- a/lib/mate/pipeline.ex
+++ b/lib/mate/pipeline.ex
@@ -11,7 +11,7 @@ defmodule Mate.Pipeline do
 
       config :mate,
         steps: fn steps, pipeline ->
-          pipeline.insert_before(steps, Mate.Step.VerifyGit, CustomStep)
+          pipeline.insert_before(steps, Mate.Step.CleanBuild, CustomStep)
         end,
 
         defmodule CustomStep do
@@ -35,14 +35,14 @@ defmodule Mate.Pipeline do
     CopyToStorage,
     LinkBuildSecrets,
     CleanBuild,
+    MixCompile,
     MixDigest,
     MixDeps,
     MixRelease,
     NpmBuild,
     NpmInstall,
-    SendGitCommit,
+    PrepareSource,
     VerifyElixir,
-    VerifyGit,
     VerifyNode
   }
 
@@ -65,11 +65,11 @@ defmodule Mate.Pipeline do
 
     steps = [
       VerifyElixir,
-      VerifyGit,
-      SendGitCommit,
+      PrepareSource,
       LinkBuildSecrets,
       CleanBuild,
       MixDeps,
+      MixCompile,
       MixRelease,
       CopyToStorage
     ]

--- a/lib/mate/pipeline/step.ex
+++ b/lib/mate/pipeline/step.ex
@@ -8,14 +8,6 @@ defmodule Mate.Pipeline.Step do
       import Mate.Helpers
       alias Mate.Utils
       use Mate.Session
-
-      @spec bail(String.t()) :: no_return
-      @spec bail(String.t(), String.t()) :: no_return
-      defp bail(message, error \\ "") do
-        if error != "",
-          do: Mix.raise("#{message}\r\n\r\n#{error}"),
-          else: Mix.raise(message)
-      end
     end
   end
 

--- a/lib/mate/remote.ex
+++ b/lib/mate/remote.ex
@@ -45,7 +45,7 @@ defmodule Mate.Remote do
     deploy_server = Map.get(remote, :deploy_server) || remote.server
 
     if is_nil(build_server), do: Mix.raise("Missing build server configuration")
-    if is_nil(deploy_server), do: Mix.raise("Missing build server configuration")
+    if is_nil(deploy_server), do: Mix.raise("Missing deploy server configuration")
 
     %{remote | build_server: build_server, deploy_server: deploy_server}
   end

--- a/lib/mate/steps/build/clean_build.ex
+++ b/lib/mate/steps/build/clean_build.ex
@@ -10,7 +10,7 @@ defmodule Mate.Step.CleanBuild do
 
     for clean_path <- absolute_clean_paths do
       with {:error, error} <- remote_cmd(session, "rm", ["-rf", clean_path]),
-           do: bail("Failed to clean build directory: #{clean_path}", error)
+           do: bail(session, "Failed to clean build directory: #{clean_path}", error)
     end
 
     {:ok, session}

--- a/lib/mate/steps/build/copy_to_storage.ex
+++ b/lib/mate/steps/build/copy_to_storage.ex
@@ -9,7 +9,7 @@ defmodule Mate.Step.CopyToStorage do
     local_path = Path.absname(archive_name)
 
     with {:error, error} <- copy_from(session, remote_path, local_path),
-         do: bail("Failed to copy #{archive_name} to local storage.", error)
+         do: bail(session, "Failed to copy #{archive_name} to local storage.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/link_build_secrets.ex
+++ b/lib/mate/steps/build/link_build_secrets.ex
@@ -27,7 +27,7 @@ defmodule Mate.Step.LinkBuildSecrets do
       """
 
       with {:error, error} <- remote_script(session, script),
-           do: bail("Failed to link #{config_name} to #{secret_file}.", error)
+           do: bail(session, "Failed to link #{config_name} to #{secret_file}.", error)
     end
 
     {:ok, session}

--- a/lib/mate/steps/build/mix_compile.ex
+++ b/lib/mate/steps/build/mix_compile.ex
@@ -1,5 +1,5 @@
-defmodule Mate.Step.MixDeps do
-  @moduledoc "This will install the mix dependencies."
+defmodule Mate.Step.MixCompile do
+  @moduledoc "This will run `mix compile` on the build server."
   use Mate.Pipeline.Step
 
   @impl true
@@ -9,12 +9,11 @@ defmodule Mate.Step.MixDeps do
     set -euo pipefail
     export MIX_ENV="#{config.mix_env}"
     cd "#{remote.build_path}"
-    mix local.hex --force && \
-      mix deps.get --only prod
+    mix compile
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to download mix dependencies.", error)
+         do: bail("Failed to compile application.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/mix_compile.ex
+++ b/lib/mate/steps/build/mix_compile.ex
@@ -13,7 +13,7 @@ defmodule Mate.Step.MixCompile do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to compile application.", error)
+         do: bail(session, "Failed to compile application.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/mix_deps.ex
+++ b/lib/mate/steps/build/mix_deps.ex
@@ -14,7 +14,7 @@ defmodule Mate.Step.MixDeps do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to download mix dependencies.", error)
+         do: bail(session, "Failed to download mix dependencies.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/mix_release.ex
+++ b/lib/mate/steps/build/mix_release.ex
@@ -17,10 +17,13 @@ defmodule Mate.Step.MixRelease do
       {:ok, assign(session, :release_archive, tar_gz)}
     else
       {:error, "tar.gz not found"} ->
-        bail("Could not find tar.gz release, is your mix project configured with `:tar`?")
+        bail(
+          session,
+          "Could not find tar.gz release, is your mix project configured with `:tar`?"
+        )
 
       {:error, error} ->
-        bail("Failed to run mix release.", error)
+        bail(session, "Failed to run mix release.", error)
     end
   end
 

--- a/lib/mate/steps/build/npm_build.ex
+++ b/lib/mate/steps/build/npm_build.ex
@@ -12,7 +12,7 @@ defmodule Mate.Step.NpmBuild do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to build front-end dependencies.", error)
+         do: bail(session, "Failed to build front-end dependencies.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/npm_install.ex
+++ b/lib/mate/steps/build/npm_install.ex
@@ -12,7 +12,7 @@ defmodule Mate.Step.NpmInstall do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to download all front-end dependencies.", error)
+         do: bail(session, "Failed to download all front-end dependencies.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/prepare_source.ex
+++ b/lib/mate/steps/build/prepare_source.ex
@@ -1,0 +1,16 @@
+defmodule Mate.Step.PrepareSource do
+  @moduledoc """
+  This will prepare the source code for building, for example when using the
+  `Mate.Driver.SSH` driver it will push the latest commit to the build server.
+  """
+  use Mate.Pipeline.Step
+
+  @impl true
+  def run(%{driver: driver} = session) do
+    with true <- function_exported?(driver, :prepare_source, 1),
+         {:error, error} <- driver.prepare_source(session),
+         do: bail("Failed to push commit to build_server.", error)
+
+    {:ok, session}
+  end
+end

--- a/lib/mate/steps/build/prepare_source.ex
+++ b/lib/mate/steps/build/prepare_source.ex
@@ -9,7 +9,7 @@ defmodule Mate.Step.PrepareSource do
   def run(%{driver: driver} = session) do
     with true <- function_exported?(driver, :prepare_source, 1),
          {:error, error} <- driver.prepare_source(session),
-         do: bail("Failed to push commit to build_server.", error)
+         do: bail(session, "Failed to push commit to build_server.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/send_git_commit.ex
+++ b/lib/mate/steps/build/send_git_commit.ex
@@ -9,7 +9,7 @@ defmodule Mate.Step.SendGitCommit do
 
     with {:error, error} <-
            local_cmd(session, "git", ~w{push #{git_remote_name} #{git_branch}}),
-         do: bail("Failed to push commit to build_server.", error)
+         do: bail(session, "Failed to push commit to build_server.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/verify_elixir.ex
+++ b/lib/mate/steps/build/verify_elixir.ex
@@ -5,10 +5,10 @@ defmodule Mate.Step.VerifyElixir do
   @impl true
   def run(session) do
     with {:error, error} <- remote_cmd(session, "which", ["elixir"]),
-         do: bail("Elixir not found in PATH on remote server.", error)
+         do: bail(session, "Elixir not found in PATH on remote server.", error)
 
     with {:error, error} <- remote_cmd(session, "which", ["mix"]),
-         do: bail("Mix not found in PATH on remote server.", error)
+         do: bail(session, "Mix not found in PATH on remote server.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/build/verify_git.ex
+++ b/lib/mate/steps/build/verify_git.ex
@@ -26,7 +26,7 @@ defmodule Mate.Step.VerifyGit do
     """
 
     with {:error, _error} <- remote_script(session, test_writable),
-         do: bail("Build user not allowed to write to #{remote.build_path}")
+         do: bail(session, "Build user not allowed to write to #{remote.build_path}")
 
     # Understand local branch
     branch =
@@ -35,10 +35,10 @@ defmodule Mate.Step.VerifyGit do
         branch
       else
         {:ok, ""} ->
-          bail("Current git branch name empty? Check `git rev-parse --abbrev-ref HEAD`")
+          bail(session, "Current git branch name empty? Check `git rev-parse --abbrev-ref HEAD`")
 
         {:error, error} ->
-          bail("Failed to get current branch name", error)
+          bail(session, "Failed to get current branch name", error)
       end
 
     script = """
@@ -53,7 +53,7 @@ defmodule Mate.Step.VerifyGit do
 
     # Setup remote
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to ensure git on remote host.", error)
+         do: bail(session, "Failed to ensure git on remote host.", error)
 
     # Setup local
     git_remote_name = "mate-#{remote.id}"
@@ -63,7 +63,7 @@ defmodule Mate.Step.VerifyGit do
            local_cmd(session, "git", ~w{remote get-url #{git_remote_name}}),
          {:error, error} <-
            local_cmd(session, "git", ~w{remote add #{git_remote_name} #{git_remote_url}}),
-         do: bail("Failed to ensure remote origin on local git repository.", error)
+         do: bail(session, "Failed to ensure remote origin on local git repository.", error)
 
     {:ok, session |> assign(:git_branch, branch)}
   end

--- a/lib/mate/steps/build/verify_node.ex
+++ b/lib/mate/steps/build/verify_node.ex
@@ -5,10 +5,10 @@ defmodule Mate.Step.VerifyNode do
   @impl true
   def run(session) do
     with {:error, error} <- remote_cmd(session, "which", ["node"]),
-         do: bail("Node not found in PATH on remote server.", error)
+         do: bail(session, "Node not found in PATH on remote server.", error)
 
     with {:error, error} <- remote_cmd(session, "which", ["npm"]),
-         do: bail("NPM not found in PATH on remote server.", error)
+         do: bail(session, "NPM not found in PATH on remote server.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/deploy/copy_to_deploy_host.ex
+++ b/lib/mate/steps/deploy/copy_to_deploy_host.ex
@@ -19,10 +19,10 @@ defmodule Mate.Step.CopyToDeployHost do
     """
 
     with {:error, _error} <- remote_script(session, test_writable),
-         do: bail("Deploy user not allowed to write to #{remote.release_path}")
+         do: bail(session, "Deploy user not allowed to write to #{remote.release_path}")
 
     with {:error, error} <- copy_to(session, local_path, remote_path),
-         do: bail("Failed to copy #{archive_name} to deploy host.", error)
+         do: bail(session, "Failed to copy #{archive_name} to deploy host.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/deploy/start_release.ex
+++ b/lib/mate/steps/deploy/start_release.ex
@@ -17,7 +17,7 @@ defmodule Mate.Step.StartRelease do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to start #{otp_app}.", error)
+         do: bail(session, "Failed to start #{otp_app}.", error)
 
     {:ok, session}
   end

--- a/lib/mate/steps/deploy/unarchive_release.ex
+++ b/lib/mate/steps/deploy/unarchive_release.ex
@@ -15,7 +15,7 @@ defmodule Mate.Step.UnarchiveRelease do
     """
 
     with {:error, error} <- remote_script(session, script),
-         do: bail("Failed to unarchive #{archive_name}.", error)
+         do: bail(session, "Failed to unarchive #{archive_name}.", error)
 
     {:ok, session}
   end

--- a/priv/run-wrapper.sh
+++ b/priv/run-wrapper.sh
@@ -6,6 +6,10 @@
 exec "$@" &
 pid1=$!
 
+# The docker client needs to be killed with the right signal for it to tell
+# the docker daemon to kill the container as well.
+trap "kill -1 $pid1" SIGINT SIGKILL EXIT
+
 # Silence warnings from here on
 exec >/dev/null 2>&1
 
@@ -13,7 +17,7 @@ exec >/dev/null 2>&1
 # kill running program when stdin closes
 exec 0<&0 $(
   while read; do :; done
-  kill -KILL $pid1
+  kill -1 $pid1
 ) &
 pid2=$!
 

--- a/priv/run-wrapper.sh
+++ b/priv/run-wrapper.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# See: https://hexdocs.pm/elixir/Port.html#module-zombie-operating-system-processes
+
+# Start the program in the background
+exec "$@" &
+pid1=$!
+
+# Silence warnings from here on
+exec >/dev/null 2>&1
+
+# Read from stdin in the background and
+# kill running program when stdin closes
+exec 0<&0 $(
+  while read; do :; done
+  kill -KILL $pid1
+) &
+pid2=$!
+
+# Clean up
+wait $pid1
+ret=$?
+kill -KILL $pid2
+exit $ret


### PR DESCRIPTION
This PR adds support for a Docker driver for building your application in a local docker container. 

Maybe important to note that the output will still be a `.tar.gz` that is uploaded via ssh to the deploy host(s). It will not result in a docker container, then you are better off using a `Dockerfile`. It's also important to note that your architecture needs to be the same for this to be a viable option – if I build something on my local laptop it will result in aarch64 (ARM) which is not compatible with my VPS (amd64).

Getting this done required some changes to some other internals as well, for example previously it was a step in the pipeline to send the code to the remote. However when using this Docker driver this should not happen over SSH, so the logic for sending your code to the build machine or container has moved into the driver as well.

If you are building a Phoenix project, you'll want a docker image that has the right versions of OTP, Elixir and NodeJS, but to make it easy I also wanted to include a default image that just uses `latest`. I ended up using `bitwalker/alpine-elixir-phoenix` as a default image, but it should be possible to override this by the user. This has been added by introducing `driver_opts` to the `.mate.exs` configuration file.

Example configuration using Docker:

```elixir
import Config

config :mate,
  otp_app: :example,
  module: Example,
  driver: Mate.Driver.Docker,
  driver_opts: [
    image: "bitwalker/alpine-elixir-phoenix"
  ]

config :staging,
  server: "www.example.com",
  build_path: "/tmp/build/example",
  release_path: "/home/elixir/releases/example.com",
  build_secrets: %{
    "prod.secret.exs" => "/repo/config/prod.secret.exs"
  }
```