### PR TITLE
[WIP] added ability to run pre_deploy and post_deploy scripts

### DIFF
--- a/lib/mate/remote.ex
+++ b/lib/mate/remote.ex
@@ -13,6 +13,8 @@ defmodule Mate.Remote do
     :release_path,
     :build_server,
     :deploy_server,
+    pre_deploy: [],
+    post_deploy: [],
     build_secrets: %{}
   ]
 
@@ -23,7 +25,9 @@ defmodule Mate.Remote do
           release_path: String.t(),
           build_server: String.t(),
           deploy_server: String.t() | list(String.t()),
-          build_secrets: map()
+          build_secrets: map(),
+          pre_deploy: list({:rpc | :eval, String.t() | list(String.t())}),
+          post_deploy: list({:rpc | :eval, String.t() | list(String.t())})
         }
 
   @doc "Creates a new `Mate.Remote` stuct with the given id and parameters."

--- a/lib/mate/steps/deploy/run_post_deploy.ex
+++ b/lib/mate/steps/deploy/run_post_deploy.ex
@@ -1,0 +1,19 @@
+defmodule Mate.Step.RunPostDeploy do
+  @moduledoc "Runs commands on the deploy targets after starting."
+  use Mate.Pipeline.Step
+
+  @impl true
+  def run(%{remote: remote, config: %{otp_app: otp_app}} = session) do
+    otp_app_bin = Path.join(remote.release_path, "/bin/#{otp_app}")
+
+    for {command, args} <- remote.post_deploy do
+      args = List.flatten([to_string(command) | [args]])
+
+      with {:error, error} <- remote_cmd(session, otp_app_bin, args),
+           do:
+             bail(session, "Failed to run #{otp_app} #{command} #{Enum.join(args, " ")}.", error)
+    end
+
+    {:ok, session}
+  end
+end

--- a/lib/mate/steps/deploy/run_pre_deploy.ex
+++ b/lib/mate/steps/deploy/run_pre_deploy.ex
@@ -1,0 +1,19 @@
+defmodule Mate.Step.RunPreDeploy do
+  @moduledoc "Runs commands on the deploy targets before starting."
+  use Mate.Pipeline.Step
+
+  @impl true
+  def run(%{remote: remote, config: %{otp_app: otp_app}} = session) do
+    otp_app_bin = Path.join(remote.release_path, "/bin/#{otp_app}")
+
+    for {command, args} <- remote.pre_deploy do
+      args = List.flatten([to_string(command) | [args]])
+
+      with {:error, error} <- remote_cmd(session, otp_app_bin, args),
+           do:
+             bail(session, "Failed to run #{otp_app} #{command} #{Enum.join(args, " ")}.", error)
+    end
+
+    {:ok, session}
+  end
+end

--- a/lib/mix/tasks/mate.deploy.ex
+++ b/lib/mix/tasks/mate.deploy.ex
@@ -6,7 +6,9 @@ defmodule Mix.Tasks.Mate.Deploy do
     CopyToDeployHost,
     StopRelease,
     UnarchiveRelease,
-    StartRelease
+    StartRelease,
+    RunPreDeploy,
+    RunPostDeploy
   }
 
   use Mix.Task
@@ -68,7 +70,9 @@ defmodule Mix.Tasks.Mate.Deploy do
             CopyToDeployHost,
             StopRelease,
             UnarchiveRelease,
-            StartRelease
+            RunPreDeploy,
+            StartRelease,
+            RunPostDeploy
           ])
       )
 


### PR DESCRIPTION
This introduces new functionality to Mate to run certain commands on your application either pre or post deploy. This could be used for database migrations for example.

I am not yet sure this is the cleanest way to implement this, so I might revise it later but I am going to play with it in a personal project for a while to see what works and doesn't. 

**Jan 5, 2020 Update** Just wanted to post an update on why this is delayed; I simply didn't have time to work on a hobby project I'm using `mate` for, and required this functionality. I'm also not satisfied with the wip implementation so I'll need to take some time to think of something that feels better.